### PR TITLE
Fix JS error 'Uncaught SyntaxError: Unexpected identifier'.

### DIFF
--- a/includes/class-gmw-maps-api.php
+++ b/includes/class-gmw-maps-api.php
@@ -284,7 +284,7 @@ class GMW_Maps_API {
 		$default_map_options = array(
 			'defaultCenter'          => '40.758895,-73.985131', // belongs to GMW.
 			'layersUrl'              => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', // for leaflet
-			'layersAttribution'      => '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors', // for leaflet
+			'layersAttribution'      => '&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors', // for leaflet
 			'backgroundColor'        => '#f7f5e8',
 			'disableDefaultUI'       => false,
 			'disableDoubleClickZoom' => false,


### PR DESCRIPTION
When I upgraded from version 2 to 3.1 my maps would not load at all due to a JS error in Chrome "Uncaught SyntaxError: Unexpected identifier".  To resolve I escaped the double quotes.

It would be great to have this fix added to the module to avoid having to re-add it each time I upgrade.

Cheers,

John