### PR TITLE
Guard against non-array address and post values in form submission

### DIFF
--- a/includes/class-gmw-form.php
+++ b/includes/class-gmw-form.php
@@ -276,7 +276,7 @@ class GMW_Form extends GMW_Form_Core {
 		$form_values = $this->form['form_values'];
 
 		$this->form['radius']      = isset( $form_values['distance'] ) ? $form_values['distance'] : 500;
-		$this->form['address']     = ( isset( $form_values['address'] ) && array_filter( $form_values['address'] ) ) ? implode( ' ', $form_values['address'] ) : '';
+		$this->form['address']     = ( isset( $form_values['address'] ) && is_array( $form_values['address'] ) && array_filter( $form_values['address'] ) ) ? implode( ' ', $form_values['address'] ) : '';
 		$this->form['org_address'] = $this->form['address'];
 		$this->form['units']       = isset( $form_values['units'] ) ? $form_values['units'] : 'imperial';
 		$this->form['units_array'] = gmw_get_units_array( $this->form['units'] );

--- a/plugins/posts-locator/includes/class-gmw-posts-locator-form.php
+++ b/plugins/posts-locator/includes/class-gmw-posts-locator-form.php
@@ -45,7 +45,7 @@ trait GMW_Posts_Locator_Form_Trait {
 		} else {
 
 			// Check in submitted values.
-			if ( ! empty( $this->form['form_values']['post'] ) && array_filter( $this->form['form_values']['post'] ) ) {
+			if ( ! empty( $this->form['form_values']['post'] ) && is_array( $this->form['form_values']['post'] ) && array_filter( $this->form['form_values']['post'] ) ) {
 
 				$post_types = $this->form['form_values']['post'];
 


### PR DESCRIPTION
A request like `/?address=example&post=event` (without the `[]` array brackets) makes `parse_str` produce strings for `address` and `post`, and `array_filter()` then throws `TypeError: array_filter(): Argument #1 ($array) must be of type array, string given`, taking down the page. This adds an `is_array()` check before `array_filter()` in both form classes so a non-array value falls through to the existing default. Fixes #84.
